### PR TITLE
Support MemoryReservation

### DIFF
--- a/src/main/scala/se/marcuslonnberg/scaladocker/remote/models/container.scala
+++ b/src/main/scala/se/marcuslonnberg/scaladocker/remote/models/container.scala
@@ -92,7 +92,6 @@ case class ContainerConfig(
   user: Option[String] = None,
   hostname: Option[String] = None,
   domainName: Option[String] = None,
-  resourceLimits: ContainerResourceLimits = ContainerResourceLimits(),
   standardStreams: StandardStreamsConfig = StandardStreamsConfig(),
   labels: Map[String, String] = Map.empty,
   networkDisabled: Boolean = false
@@ -148,10 +147,6 @@ case class ContainerConfig(
     copy(domainName = Option(domainName).filter(_.nonEmpty))
   }
 
-  def withResourceLimits(resourceLimits: ContainerResourceLimits) = {
-    copy(resourceLimits = resourceLimits)
-  }
-
   def withStandardStreams(standardStreams: StandardStreamsConfig) = {
     copy(standardStreams = standardStreams)
   }
@@ -196,6 +191,7 @@ case class StandardStreamsConfig(
 case class ContainerResourceLimits(
   memory: Long = 0,
   memorySwap: Long = 0,
+  memoryReservation: Long = 0,
   cpuShares: Long = 0,
   cpuset: Option[String] = None
 )
@@ -244,6 +240,7 @@ case class HostConfig(
   networkMode: Option[String] = None,
   privileged: Boolean = false,
   capabilities: LinuxCapabilities = LinuxCapabilities(),
+  resourceLimits: ContainerResourceLimits = ContainerResourceLimits(),
   restartPolicy: RestartPolicy = NeverRestart
 ) {
   def withPortBindings(ports: (Port, Seq[PortBinding])*) = {
@@ -297,6 +294,11 @@ case class HostConfig(
   def withRestartPolicy(restartPolicy: RestartPolicy) = {
     copy(restartPolicy = restartPolicy)
   }
+
+  def withResourceLimits(resourceLimits: ContainerResourceLimits) = {
+    copy(resourceLimits = resourceLimits)
+  }
+
 }
 
 /**

--- a/src/main/scala/se/marcuslonnberg/scaladocker/remote/models/json/ContainerFormats.scala
+++ b/src/main/scala/se/marcuslonnberg/scaladocker/remote/models/json/ContainerFormats.scala
@@ -55,8 +55,9 @@ trait ContainerFormats extends CommonFormats {
   implicit val containerResourceLimitsFormat: OFormat[ContainerResourceLimits] =
     ((JsPath \ "Memory").formatWithDefault[Long](0) and
       (JsPath \ "MemorySwap").formatWithDefault[Long](0) and
+      (JsPath \ "MemoryReservation").formatWithDefault[Long](0) and
       (JsPath \ "CpuShares").formatWithDefault[Long](0) and
-      (JsPath \ "Cpuset").formatNullable[String]
+      (JsPath \ "CpusetCpus").formatNullable[String]
       ) (ContainerResourceLimits.apply, unlift(ContainerResourceLimits.unapply))
 
   implicit val containerConfigFormat: OFormat[ContainerConfig] =
@@ -71,7 +72,6 @@ trait ContainerFormats extends CommonFormats {
       (JsPath \ "User").formatNullable[String] and
       (JsPath \ "Hostname").formatNullable[String] and
       (JsPath \ "DomainName").formatNullable[String] and
-      containerResourceLimitsFormat and
       standardStreamsConfigFormat and
       (JsPath \ "Labels").formatWithDefault[Map[String, String]](Map.empty) and
       (JsPath \ "NetworkDisabled").formatWithDefault[Boolean](false)
@@ -125,6 +125,7 @@ trait ContainerFormats extends CommonFormats {
       (JsPath \ "NetworkMode").formatNullable[String].inmap[Option[String]](_.filter(_.nonEmpty), identity) and
       (JsPath \ "Privileged").formatWithDefault[Boolean](false) and
       capabilitiesConfigFormat and
+      containerResourceLimitsFormat and
       (JsPath \ "RestartPolicy").formatWithDefault[RestartPolicy](NeverRestart)
       ) (HostConfig.apply, unlift(HostConfig.unapply))
 


### PR DESCRIPTION
Moved ContainerResourceLimits to hostConfig since that seems to be the correct location according to [docs](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#create-a-container)